### PR TITLE
Remove inaccurate fiat display from message

### DIFF
--- a/src/tpl/jinja2/tip-received.tpl
+++ b/src/tpl/jinja2/tip-received.tpl
@@ -15,7 +15,7 @@
 {% endif %}
 {% set coinval_fmt = "%s%s%.6g %s%s" % (amount_prefix_short, ctb.conf.coins[a.coin].symbol, coin_amount, amount_prefix_long, ctb.conf.coins[a.coin].name) %}
 {% set fiatval_fmt = "%s%.3f" % (ctb.conf.fiat[a.fiat].symbol, a.fiatval) %}
-Hey {{ user_to | replace('_', '\_') }}, you have received a __{{ coinval_fmt }} ({{ fiatval_fmt }})__ tip from /u/{{ user_from }}.
+Hey {{ user_to | replace('_', '\_') }}, you have received a __{{ coinval_fmt }}{{ ' (%s)' % fiatval_fmt if a.fiatval }}__ tip from /u/{{ user_from }}.
 
 {% set user = user_to %}
 {% include 'footer.tpl' %}


### PR DESCRIPTION
The fiat conversion is sometimes inaccurate in the balance display. Specifically it is sometimes displayed as $0.0 when it is actually supposed to be a value higher than $0. This could be caused by an error where the conversion rates cannot be fetched, so I made a change in the template that hides the fiat value if it is $0 which I would figure is better than showing it incorrectly.

Example:

``` python
t = Template("you have received a __{{ coinval_fmt }}{{ ' (%s)' % fiatval_fmt if fiatval }}__ tip")
# Fiat value is legit, go ahead and display it.
>>> t.render(coinval_fmt='Ð500 Dogecoin', fiatval_fmt='$0.060', fiatval=0.06)
'you have received a __Ð500 Dogecoin ($0.060)__ tip'
# Error getting fiat value, don't show.
>>> t.render(coinval_fmt='Ð500 Dogecoin', fiatval_fmt='$0.060', fiatval=0.0)
'you have received a __Ð500 Dogecoin__ tip'
```
